### PR TITLE
Dotnet Watch

### DIFF
--- a/WikiLinks.Api/WikiLinks.Api.csproj
+++ b/WikiLinks.Api/WikiLinks.Api.csproj
@@ -20,8 +20,4 @@
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />
   </ItemGroup>
 
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
-  </ItemGroup>
-
 </Project>

--- a/WikiLinks.Test/WikiLinks.Test.csproj
+++ b/WikiLinks.Test/WikiLinks.Test.csproj
@@ -20,8 +20,4 @@
   <ItemGroup>
     <ProjectReference Include="..\WikiLinks.Domain\WikiLinks.Domain.csproj" />
   </ItemGroup>
-	
-  <ItemGroup>
- 	<DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Removing references to `Microsoft.DotNet.Watcher.Tools` since it the reference is no longer necessary. Also it gets rid of the infuriating warnings generated by the compiler.