### PR TITLE
Markdown Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WikiLinks
 
+[![Build status](https://ci.appveyor.com/api/projects/status/fqfk62y1ly1jd9oa?svg=true)](https://ci.appveyor.com/project/DillonAd/wikilinks)
+
 ## Purpose
 
 I have always loved the idea of Wikis. So much so that the current state of how most are organized is unconscionable. My goal is to provide a framework that will parse the most common Markdown uses for each article, and provide an easy to use navigation infrastructure so users can easily find related articles.

--- a/WikiLinks.Domain/Markdown.cs
+++ b/WikiLinks.Domain/Markdown.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Text;
 using System.Collections.Generic;
 using WikiLinks.Domain.MarkdownRules;
 
@@ -15,16 +17,27 @@ namespace WikiLinks.Domain
         public string Parse(string content)
         {
             if (string.IsNullOrWhiteSpace(content))
-                return string.Empty;
-
-            string parsedContent = content;
-
-            foreach(var rule in _Rules)
             {
-                parsedContent = rule.Parse(parsedContent);
+                return string.Empty;
             }
 
-            return parsedContent;
+            var sb = new StringBuilder();
+            var lines = content.Split('\n');
+
+            var line = string.Empty;
+
+            for(int i = 0; i < lines.Length; i++)
+            {
+                foreach(var rule in _Rules)
+                {
+                    line = rule.Parse(lines[i]);
+                }
+
+                sb.Append(line)
+                  .Append(Environment.NewLine);
+            }
+
+            return sb.ToString();
         }
     }
 }

--- a/WikiLinks.Domain/MarkdownRules/Header1Rule.cs
+++ b/WikiLinks.Domain/MarkdownRules/Header1Rule.cs
@@ -6,6 +6,6 @@ namespace WikiLinks.Domain.MarkdownRules
         private const string _HtmlBeginTag = "<h1>";
         private const string _HtmlEndTag = "</h1>";
 
-        public Header1Rule() : base(_MarkdownTag, _HtmlBeginTag, _HtmlEndTag) { }
+        public Header1Rule() : base(_MarkdownTag, _HtmlBeginTag, _HtmlEndTag, TagStyle.Both, true) { }
     }
 }

--- a/WikiLinks.Domain/MarkdownRules/Header2Rule.cs
+++ b/WikiLinks.Domain/MarkdownRules/Header2Rule.cs
@@ -6,6 +6,6 @@ namespace WikiLinks.Domain.MarkdownRules
         private const string _HtmlBeginTag = "<h2>";
         private const string _HtmlEndTag = "</h2>";
 
-        public Header2Rule() : base(_MarkdownTag, _HtmlBeginTag, _HtmlEndTag) { }
+        public Header2Rule() : base(_MarkdownTag, _HtmlBeginTag, _HtmlEndTag, TagStyle.Both, true) { }
     }
 }

--- a/WikiLinks.Domain/MarkdownRules/Header3Rule.cs
+++ b/WikiLinks.Domain/MarkdownRules/Header3Rule.cs
@@ -6,6 +6,6 @@ namespace WikiLinks.Domain.MarkdownRules
         private const string _HtmlBeginTag = "<h3>";
         private const string _HtmlEndTag = "</h3>";
 
-        public Header3Rule() : base(_MarkdownTag, _HtmlBeginTag, _HtmlEndTag) { }
+        public Header3Rule() : base(_MarkdownTag, _HtmlBeginTag, _HtmlEndTag, TagStyle.Both, true) { }
     }
 }

--- a/WikiLinks.Domain/MarkdownRules/Header4Rule.cs
+++ b/WikiLinks.Domain/MarkdownRules/Header4Rule.cs
@@ -6,6 +6,6 @@ namespace WikiLinks.Domain.MarkdownRules
         private const string _HtmlBeginTag = "<h4>";
         private const string _HtmlEndTag = "</h4>";
 
-        public Header4Rule() : base(_MarkdownTag, _HtmlBeginTag, _HtmlEndTag) { }
+        public Header4Rule() : base(_MarkdownTag, _HtmlBeginTag, _HtmlEndTag, TagStyle.Both, true) { }
     }
 }

--- a/WikiLinks.Domain/MarkdownRules/Header5Rule.cs
+++ b/WikiLinks.Domain/MarkdownRules/Header5Rule.cs
@@ -6,6 +6,6 @@ namespace WikiLinks.Domain.MarkdownRules
         private const string _HtmlBeginTag = "<h5>";
         private const string _HtmlEndTag = "</h5>";
 
-        public Header5Rule() : base(_MarkdownTag, _HtmlBeginTag, _HtmlEndTag) { }
+        public Header5Rule() : base(_MarkdownTag, _HtmlBeginTag, _HtmlEndTag, TagStyle.Both, true) { }
     }
 }

--- a/WikiLinks.Domain/MarkdownRules/Header6Rule.cs
+++ b/WikiLinks.Domain/MarkdownRules/Header6Rule.cs
@@ -6,6 +6,6 @@ namespace WikiLinks.Domain.MarkdownRules
         private const string _HtmlBeginTag = "<h6>";
         private const string _HtmlEndTag = "</h6>";
 
-        public Header6Rule() : base(_MarkdownTag, _HtmlBeginTag, _HtmlEndTag) { }
+        public Header6Rule() : base(_MarkdownTag, _HtmlBeginTag, _HtmlEndTag, TagStyle.Both, true) { }
     }
 }

--- a/WikiLinks.Domain/MarkdownRules/MarkdownRule.cs
+++ b/WikiLinks.Domain/MarkdownRules/MarkdownRule.cs
@@ -1,40 +1,62 @@
+using System;
+using System.Text;
+
 namespace WikiLinks.Domain.MarkdownRules
 {
     public abstract class MarkdownRule
     {
         protected string MarkdownTag { get; }
-        protected string HtmlBeginTag { get; }
-        protected string HtmlEndTag { get; }
-        protected bool IsMarkdownTagPair { get; }
+        protected string HtmlBeginTag => _htmlBeginTag;
+        protected string HtmlEndTag => _htmlEndTag;
+        protected TagStyle TagStyle { get; }
+        protected bool RequireSpace { get; } 
 
-        protected internal MarkdownRule(string markdownTag, string htmlBeginTag, string htmlEndTag, bool isMarkdownTagPair = false)
+        private readonly string _htmlBeginTag;
+        private readonly string _htmlEndTag;
+
+        protected internal MarkdownRule(string markdownTag, string htmlBeginTag, string htmlEndTag, TagStyle tagStyle = TagStyle.Matching, bool requireSpace = false)
         {
             MarkdownTag = markdownTag;
-            HtmlBeginTag = htmlBeginTag;
-            HtmlEndTag = htmlEndTag;
-            IsMarkdownTagPair = isMarkdownTagPair;
+            _htmlBeginTag = htmlBeginTag;
+            _htmlEndTag = htmlEndTag;
+            TagStyle = tagStyle;
+            RequireSpace = requireSpace;
         }
 
         public string Parse(string content)
         {
-            string inProgressContent;
-            string newContent = content;
+            var sb = new StringBuilder();
+            var lines = content.Split('\n');
 
-            foreach (var line in content.Split('\n'))
+            var line = string.Empty;
+
+            for(int i = 0; i < lines.Length; i++)
             {
-                while (HasMatchingTags(newContent))
+                line = lines[i];
+                if(TagStyle == TagStyle.Matching || TagStyle == TagStyle.Both)
                 {
-                    inProgressContent = ReplaceTag(newContent, HtmlBeginTag);
-                    inProgressContent = ReplaceTag(inProgressContent, HtmlEndTag);
-
-                    newContent = inProgressContent;
+                    while (HasMatchingTags(ref line))
+                    {
+                        line = ReplaceTag(line, HtmlBeginTag, HtmlEndTag, MarkdownTag);
+                    }
                 }
+
+                if(TagStyle == TagStyle.Single || TagStyle == TagStyle.Both)
+                {
+                    if(line.TrimStart().StartsWith(MarkdownTag))
+                    {
+                        line = ReplaceTag(line, HtmlBeginTag, HtmlEndTag, MarkdownTag);
+                    }
+                }
+
+                sb.Append(line)
+                  .Append(Environment.NewLine);
             }
 
-            return newContent;
+            return sb.ToString();
         }
 
-        private bool HasMatchingTags(string content)
+        private bool HasMatchingTags(ref string content)
         {
             var beginTagIndex = content.IndexOf(MarkdownTag);
 
@@ -45,19 +67,49 @@ namespace WikiLinks.Domain.MarkdownRules
 
             var endTagIndex = content.IndexOf(MarkdownTag, beginTagIndex + MarkdownTag.Length);
             
-            return beginTagIndex >= 0
-                    && endTagIndex > beginTagIndex
-                    && beginTagIndex != endTagIndex;
+            return beginTagIndex >= 0 &&
+                   endTagIndex > beginTagIndex &&
+                   beginTagIndex != endTagIndex;
         }
 
-        private string ReplaceTag(string content, string replacementTag)
+        private string ReplaceTag(string content, string replacementBeginTag, string replacementEndTag, string markdownTag)
         {
-            int tagBeginIndex = content.IndexOf(MarkdownTag);
-            int tagEndIndex = tagBeginIndex + MarkdownTag.Length;
+            var sb = new StringBuilder();
 
-            return content.Substring(0, tagBeginIndex) +
-                    replacementTag +
-                    content.Substring(tagEndIndex);
+            int tagBeginIndex = content.IndexOf(markdownTag);
+            int tagEndIndex = tagBeginIndex + markdownTag.Length;
+
+            if(RequireSpace)
+            {
+                tagEndIndex++;
+            }
+
+            sb.Append(content.Substring(0, tagBeginIndex));
+            sb.Append(replacementBeginTag);
+
+            var endTagBeginIndex = content.IndexOf(markdownTag, tagEndIndex);
+            var endTagEndIndex = endTagBeginIndex + markdownTag.Length;
+
+            if(endTagBeginIndex > 0 && endTagEndIndex > 0)
+            {
+                var middleLength = endTagBeginIndex - tagEndIndex;
+                
+                if(RequireSpace)
+                {
+                    middleLength--;
+                }
+
+                sb.Append(content.Substring(tagEndIndex, middleLength));
+                sb.Append(replacementEndTag);
+                sb.Append(content.Substring(endTagEndIndex));
+            }
+            else
+            {
+                sb.Append(content.Substring(tagEndIndex, content.Length - tagEndIndex));
+                sb.Append(HtmlEndTag);
+            }
+
+            return sb.ToString();
         }
     }
 }

--- a/WikiLinks.Domain/MarkdownRules/MarkdownRule.cs
+++ b/WikiLinks.Domain/MarkdownRules/MarkdownRule.cs
@@ -23,37 +23,27 @@ namespace WikiLinks.Domain.MarkdownRules
             RequireSpace = requireSpace;
         }
 
-        public string Parse(string content)
+        public string Parse(string line)
         {
-            var sb = new StringBuilder();
-            var lines = content.Split('\n');
+            var content = line;
 
-            var line = string.Empty;
-
-            for(int i = 0; i < lines.Length; i++)
+            if(TagStyle == TagStyle.Matching || TagStyle == TagStyle.Both)
             {
-                line = lines[i];
-                if(TagStyle == TagStyle.Matching || TagStyle == TagStyle.Both)
+                while (HasMatchingTags(ref content))
                 {
-                    while (HasMatchingTags(ref line))
-                    {
-                        line = ReplaceTag(line, HtmlBeginTag, HtmlEndTag, MarkdownTag);
-                    }
+                    content = ReplaceTag(content, HtmlBeginTag, HtmlEndTag, MarkdownTag);
                 }
-
-                if(TagStyle == TagStyle.Single || TagStyle == TagStyle.Both)
-                {
-                    if(line.TrimStart().StartsWith(MarkdownTag))
-                    {
-                        line = ReplaceTag(line, HtmlBeginTag, HtmlEndTag, MarkdownTag);
-                    }
-                }
-
-                sb.Append(line)
-                  .Append(Environment.NewLine);
             }
 
-            return sb.ToString();
+            if(TagStyle == TagStyle.Single || TagStyle == TagStyle.Both)
+            {
+                if(content.TrimStart().StartsWith(MarkdownTag))
+                {
+                    content = ReplaceTag(content, HtmlBeginTag, HtmlEndTag, MarkdownTag);
+                }
+            }
+        
+            return content;
         }
 
         private bool HasMatchingTags(ref string content)

--- a/WikiLinks.Domain/MarkdownRules/TagStyle.cs
+++ b/WikiLinks.Domain/MarkdownRules/TagStyle.cs
@@ -1,0 +1,9 @@
+namespace WikiLinks.Domain.MarkdownRules
+{
+    public enum TagStyle
+    {
+        Single,
+        Matching,
+        Both
+    }
+}

--- a/WikiLinks.Domain/WikiLinks.Domain.csproj
+++ b/WikiLinks.Domain/WikiLinks.Domain.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.1" />
+  </ItemGroup>
+
 </Project>

--- a/WikiLinks.Test/Unit/MarkdownTest.cs
+++ b/WikiLinks.Test/Unit/MarkdownTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using WikiLinks.Domain;
 using WikiLinks.Domain.MarkdownRules;
@@ -8,10 +9,10 @@ namespace WikiLinks.Test.Unit
     public class MarkdownTest
     {
         [Theory]
-        [InlineData("hello **world**", "hello <b>world</b>")]
-        [InlineData("hello **world **", "hello <b>world </b>")]
-        [InlineData("hello ** world**", "hello <b> world</b>")]
-        [InlineData("hello ** world **", "hello <b> world </b>")]
+        [InlineData("hello **world**", "hello <b>world</b>\n")]
+        [InlineData("hello **world **", "hello <b>world </b>\n")]
+        [InlineData("hello ** world**", "hello <b> world</b>\n")]
+        [InlineData("hello ** world **", "hello <b> world </b>\n")]
         public void ParseBold_Single(string initial, string expected)
         {
             var br = new BoldRule();
@@ -20,10 +21,10 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("**hello** **world**", "<b>hello</b> <b>world</b>")]
-        [InlineData("**hello ** **world **", "<b>hello </b> <b>world </b>")]
-        [InlineData("** hello** ** world**", "<b> hello</b> <b> world</b>")]
-        [InlineData("** hello ** ** world **", "<b> hello </b> <b> world </b>")]
+        [InlineData("**hello** **world**", "<b>hello</b> <b>world</b>\n")]
+        [InlineData("**hello ** **world **", "<b>hello </b> <b>world </b>\n")]
+        [InlineData("** hello** ** world**", "<b> hello</b> <b> world</b>\n")]
+        [InlineData("** hello ** ** world **", "<b> hello </b> <b> world </b>\n")]
         public void ParseBold_Multiple(string initial, string expected)
         {
             var br = new BoldRule();
@@ -32,10 +33,10 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("hello _world_", "hello <i>world</i>")]
-        [InlineData("hello _world _", "hello <i>world </i>")]
-        [InlineData("hello _ world_", "hello <i> world</i>")]
-        [InlineData("hello _ world _", "hello <i> world </i>")]
+        [InlineData("hello _world_", "hello <i>world</i>\n")]
+        [InlineData("hello _world _", "hello <i>world </i>\n")]
+        [InlineData("hello _ world_", "hello <i> world</i>\n")]
+        [InlineData("hello _ world _", "hello <i> world </i>\n")]
         public void ParseItalic_Single(string initial, string expected)
         {
             var ir = new ItalicRule();
@@ -44,10 +45,10 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("_hello_ _world_", "<i>hello</i> <i>world</i>")]
-        [InlineData("_hello _ _world _", "<i>hello </i> <i>world </i>")]
-        [InlineData("_ hello_ _ world_", "<i> hello</i> <i> world</i>")]
-        [InlineData("_ hello _ _ world _", "<i> hello </i> <i> world </i>")]
+        [InlineData("_hello_ _world_", "<i>hello</i> <i>world</i>\n")]
+        [InlineData("_hello _ _world _", "<i>hello </i> <i>world </i>\n")]
+        [InlineData("_ hello_ _ world_", "<i> hello</i> <i> world</i>\n")]
+        [InlineData("_ hello _ _ world _", "<i> hello </i> <i> world </i>\n")]
         public void ParseItalic_Multiple(string initial, string expected)
         {
             var ir = new ItalicRule();
@@ -56,11 +57,10 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("hello ######world######", "hello <h6>world</h6>")]
-        [InlineData("hello ######world ######", "hello <h6>world </h6>")]
-        [InlineData("hello ###### world######", "hello <h6> world</h6>")]
-        [InlineData("hello ###### world ######", "hello <h6> world </h6>")]
-        public void ParseHeader6_Single(string initial, string expected)
+        [InlineData("###### hello ###### world", "<h6>hello</h6> world\n")]
+        [InlineData("###### hello world", "<h6>hello world</h6>\n")]
+        [InlineData(" ###### hello world", " <h6>hello world</h6>\n")]
+        public void ParseHeader6(string initial, string expected)
         {
             var hr = new Header6Rule();
             var result = hr.Parse(initial);
@@ -68,22 +68,9 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("######hello###### ######world######", "<h6>hello</h6> <h6>world</h6>")]
-        [InlineData("######hello ###### ######world ######", "<h6>hello </h6> <h6>world </h6>")]
-        [InlineData("###### hello###### ###### world######", "<h6> hello</h6> <h6> world</h6>")]
-        [InlineData("###### hello ###### ###### world ######", "<h6> hello </h6> <h6> world </h6>")]
-        public void ParseHeader6_Multiple(string initial, string expected)
-        {
-            var hr = new Header6Rule();
-            var result = hr.Parse(initial);
-            Assert.Equal(expected, result);
-        }
-
-        [Theory]
-        [InlineData("#####hello##### world", "<h5>hello</h5> world")]
-        [InlineData("#####hello ##### world", "<h5>hello </h5> world")]
-        [InlineData("##### hello##### world", "<h5> hello</h5> world")]
-        [InlineData("##### hello ##### world", "<h5> hello </h5> world")]
+        [InlineData("##### hello ##### world", "<h5>hello</h5> world\n")]
+        [InlineData("##### hello world", "<h5>hello world</h5>\n")]
+        [InlineData(" ##### hello world", " <h5>hello world</h5>\n")]
         public void ParseHeader5(string initial, string expected)
         {
             var hr = new Header5Rule();
@@ -92,10 +79,9 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("####hello#### world", "<h4>hello</h4> world")]
-        [InlineData("####hello #### world", "<h4>hello </h4> world")]
-        [InlineData("#### hello#### world", "<h4> hello</h4> world")]
-        [InlineData("#### hello #### world", "<h4> hello </h4> world")]
+        [InlineData("#### hello #### world", "<h4>hello</h4> world\n")]
+        [InlineData("#### hello world", "<h4>hello world</h4>\n")]
+        [InlineData(" #### hello world", " <h4>hello world</h4>\n")]
         public void ParseHeader4(string initial, string expected)
         {
             var hr = new Header4Rule();
@@ -104,10 +90,9 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("###hello### world", "<h3>hello</h3> world")]
-        [InlineData("###hello ### world", "<h3>hello </h3> world")]
-        [InlineData("### hello### world", "<h3> hello</h3> world")]
-        [InlineData("### hello ### world", "<h3> hello </h3> world")]
+        [InlineData("### hello ### world", "<h3>hello</h3> world\n")]
+        [InlineData("### hello world", "<h3>hello world</h3>\n")]
+        [InlineData(" ### hello world", " <h3>hello world</h3>\n")]
         public void ParseHeader3(string initial, string expected)
         {
             var hr = new Header3Rule();
@@ -116,10 +101,9 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("##hello## world", "<h2>hello</h2> world")]
-        [InlineData("##hello ## world", "<h2>hello </h2> world")]
-        [InlineData("## hello## world", "<h2> hello</h2> world")]
-        [InlineData("## hello ## world", "<h2> hello </h2> world")]
+        [InlineData("## hello ## world", "<h2>hello</h2> world\n")]
+        [InlineData("## hello world", "<h2>hello world</h2>\n")]
+        [InlineData(" ## hello world", " <h2>hello world</h2>\n")]
         public void ParseHeader2(string initial, string expected)
         {
             var hr = new Header2Rule();
@@ -128,10 +112,9 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("#hello# world", "<h1>hello</h1> world")]
-        [InlineData("#hello # world", "<h1>hello </h1> world")]
-        [InlineData("# hello# world", "<h1> hello</h1> world")]
-        [InlineData("# hello # world", "<h1> hello </h1> world")]
+        [InlineData("# hello # world", "<h1>hello</h1> world\n")]
+        [InlineData("# hello world", "<h1>hello world</h1>\n")]
+        [InlineData(" # hello world", " <h1>hello world</h1>\n")]
         public void ParseHeader1(string initial, string expected)
         {
             var hr = new Header1Rule();
@@ -139,11 +122,9 @@ namespace WikiLinks.Test.Unit
             Assert.Equal(expected, result);
         }
 
-        [Theory]
+        [Theory(Skip="Skipping until the algorithm can be refactored to not include a ridiculous amount of newlines")]
         [InlineData("**hello world")]
         [InlineData("hello _world")]
-        [InlineData("hello world ######")]
-        [InlineData("###### ")]
         public void Parse_UnmatchedTags(string inital)
         {
             var rules = GetRules();

--- a/WikiLinks.Test/Unit/MarkdownTest.cs
+++ b/WikiLinks.Test/Unit/MarkdownTest.cs
@@ -9,10 +9,10 @@ namespace WikiLinks.Test.Unit
     public class MarkdownTest
     {
         [Theory]
-        [InlineData("hello **world**", "hello <b>world</b>\n")]
-        [InlineData("hello **world **", "hello <b>world </b>\n")]
-        [InlineData("hello ** world**", "hello <b> world</b>\n")]
-        [InlineData("hello ** world **", "hello <b> world </b>\n")]
+        [InlineData("hello **world**", "hello <b>world</b>")]
+        [InlineData("hello **world **", "hello <b>world </b>")]
+        [InlineData("hello ** world**", "hello <b> world</b>")]
+        [InlineData("hello ** world **", "hello <b> world </b>")]
         public void ParseBold_Single(string initial, string expected)
         {
             var br = new BoldRule();
@@ -21,10 +21,10 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("**hello** **world**", "<b>hello</b> <b>world</b>\n")]
-        [InlineData("**hello ** **world **", "<b>hello </b> <b>world </b>\n")]
-        [InlineData("** hello** ** world**", "<b> hello</b> <b> world</b>\n")]
-        [InlineData("** hello ** ** world **", "<b> hello </b> <b> world </b>\n")]
+        [InlineData("**hello** **world**", "<b>hello</b> <b>world</b>")]
+        [InlineData("**hello ** **world **", "<b>hello </b> <b>world </b>")]
+        [InlineData("** hello** ** world**", "<b> hello</b> <b> world</b>")]
+        [InlineData("** hello ** ** world **", "<b> hello </b> <b> world </b>")]
         public void ParseBold_Multiple(string initial, string expected)
         {
             var br = new BoldRule();
@@ -33,10 +33,10 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("hello _world_", "hello <i>world</i>\n")]
-        [InlineData("hello _world _", "hello <i>world </i>\n")]
-        [InlineData("hello _ world_", "hello <i> world</i>\n")]
-        [InlineData("hello _ world _", "hello <i> world </i>\n")]
+        [InlineData("hello _world_", "hello <i>world</i>")]
+        [InlineData("hello _world _", "hello <i>world </i>")]
+        [InlineData("hello _ world_", "hello <i> world</i>")]
+        [InlineData("hello _ world _", "hello <i> world </i>")]
         public void ParseItalic_Single(string initial, string expected)
         {
             var ir = new ItalicRule();
@@ -45,10 +45,10 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("_hello_ _world_", "<i>hello</i> <i>world</i>\n")]
-        [InlineData("_hello _ _world _", "<i>hello </i> <i>world </i>\n")]
-        [InlineData("_ hello_ _ world_", "<i> hello</i> <i> world</i>\n")]
-        [InlineData("_ hello _ _ world _", "<i> hello </i> <i> world </i>\n")]
+        [InlineData("_hello_ _world_", "<i>hello</i> <i>world</i>")]
+        [InlineData("_hello _ _world _", "<i>hello </i> <i>world </i>")]
+        [InlineData("_ hello_ _ world_", "<i> hello</i> <i> world</i>")]
+        [InlineData("_ hello _ _ world _", "<i> hello </i> <i> world </i>")]
         public void ParseItalic_Multiple(string initial, string expected)
         {
             var ir = new ItalicRule();
@@ -57,9 +57,9 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("###### hello ###### world", "<h6>hello</h6> world\n")]
-        [InlineData("###### hello world", "<h6>hello world</h6>\n")]
-        [InlineData(" ###### hello world", " <h6>hello world</h6>\n")]
+        [InlineData("###### hello ###### world", "<h6>hello</h6> world")]
+        [InlineData("###### hello world", "<h6>hello world</h6>")]
+        [InlineData(" ###### hello world", " <h6>hello world</h6>")]
         public void ParseHeader6(string initial, string expected)
         {
             var hr = new Header6Rule();
@@ -68,9 +68,9 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("##### hello ##### world", "<h5>hello</h5> world\n")]
-        [InlineData("##### hello world", "<h5>hello world</h5>\n")]
-        [InlineData(" ##### hello world", " <h5>hello world</h5>\n")]
+        [InlineData("##### hello ##### world", "<h5>hello</h5> world")]
+        [InlineData("##### hello world", "<h5>hello world</h5>")]
+        [InlineData(" ##### hello world", " <h5>hello world</h5>")]
         public void ParseHeader5(string initial, string expected)
         {
             var hr = new Header5Rule();
@@ -79,9 +79,9 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("#### hello #### world", "<h4>hello</h4> world\n")]
-        [InlineData("#### hello world", "<h4>hello world</h4>\n")]
-        [InlineData(" #### hello world", " <h4>hello world</h4>\n")]
+        [InlineData("#### hello #### world", "<h4>hello</h4> world")]
+        [InlineData("#### hello world", "<h4>hello world</h4>")]
+        [InlineData(" #### hello world", " <h4>hello world</h4>")]
         public void ParseHeader4(string initial, string expected)
         {
             var hr = new Header4Rule();
@@ -90,9 +90,9 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("### hello ### world", "<h3>hello</h3> world\n")]
-        [InlineData("### hello world", "<h3>hello world</h3>\n")]
-        [InlineData(" ### hello world", " <h3>hello world</h3>\n")]
+        [InlineData("### hello ### world", "<h3>hello</h3> world")]
+        [InlineData("### hello world", "<h3>hello world</h3>")]
+        [InlineData(" ### hello world", " <h3>hello world</h3>")]
         public void ParseHeader3(string initial, string expected)
         {
             var hr = new Header3Rule();
@@ -101,9 +101,9 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("## hello ## world", "<h2>hello</h2> world\n")]
-        [InlineData("## hello world", "<h2>hello world</h2>\n")]
-        [InlineData(" ## hello world", " <h2>hello world</h2>\n")]
+        [InlineData("## hello ## world", "<h2>hello</h2> world")]
+        [InlineData("## hello world", "<h2>hello world</h2>")]
+        [InlineData(" ## hello world", " <h2>hello world</h2>")]
         public void ParseHeader2(string initial, string expected)
         {
             var hr = new Header2Rule();
@@ -112,9 +112,9 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
-        [InlineData("# hello # world", "<h1>hello</h1> world\n")]
-        [InlineData("# hello world", "<h1>hello world</h1>\n")]
-        [InlineData(" # hello world", " <h1>hello world</h1>\n")]
+        [InlineData("# hello # world", "<h1>hello</h1> world")]
+        [InlineData("# hello world", "<h1>hello world</h1>")]
+        [InlineData(" # hello world", " <h1>hello world</h1>")]
         public void ParseHeader1(string initial, string expected)
         {
             var hr = new Header1Rule();
@@ -122,7 +122,7 @@ namespace WikiLinks.Test.Unit
             Assert.Equal(expected, result);
         }
 
-        [Theory(Skip="Skipping until the algorithm can be refactored to not include a ridiculous amount of newlines")]
+        [Theory]
         [InlineData("**hello world")]
         [InlineData("hello _world")]
         public void Parse_UnmatchedTags(string inital)
@@ -131,7 +131,7 @@ namespace WikiLinks.Test.Unit
             var md = new Markdown(rules);
             var result = md.Parse(inital);
 
-            Assert.Equal(inital, result);
+            Assert.Equal(inital + Environment.NewLine, result);
         }
 
         [Theory]


### PR DESCRIPTION
Creating algorithm to parse Markdown documents.

- [x] TODO: Currently each markdown rule adds a newline character at the end of each line instead of one newline per line.