### PR TITLE
Setup for Multiline Rules & Blockquote Rule

### DIFF
--- a/WikiLinks.Domain/MarkdownRules/BlockquoteRule.cs
+++ b/WikiLinks.Domain/MarkdownRules/BlockquoteRule.cs
@@ -1,0 +1,11 @@
+namespace WikiLinks.Domain.MarkdownRules
+{
+    public class BlockquoteRule : MultilineMarkdownRule
+    {
+        private const string _MarkdownTag = ">";
+        private const string _HtmlBeginTag = "<blockquote><pre>";
+        private const string _HtmlEndTag = "</pre></blockquote>";
+
+        public BlockquoteRule() : base(_MarkdownTag, _HtmlBeginTag, _HtmlEndTag, TagStyle.Single, true) { }
+    }
+}

--- a/WikiLinks.Domain/MarkdownRules/BoldRule.cs
+++ b/WikiLinks.Domain/MarkdownRules/BoldRule.cs
@@ -1,6 +1,6 @@
 namespace WikiLinks.Domain.MarkdownRules
 {
-    public class BoldRule : MarkdownRule
+    public class BoldRule : SingleLineMarkdownRule
     {
         private const string _MarkdownTag = "**";
         private const string _HtmlBeginTag = "<b>";

--- a/WikiLinks.Domain/MarkdownRules/CodeRule.cs
+++ b/WikiLinks.Domain/MarkdownRules/CodeRule.cs
@@ -1,6 +1,6 @@
 namespace WikiLinks.Domain.MarkdownRules
 {
-    public class CodeRule : MarkdownRule
+    public class CodeRule : SingleLineMarkdownRule
     {
         private const string _MarkdownTag = "`";
         private const string _HtmlBeginTag = "<code><pre>";

--- a/WikiLinks.Domain/MarkdownRules/Header1Rule.cs
+++ b/WikiLinks.Domain/MarkdownRules/Header1Rule.cs
@@ -1,6 +1,6 @@
 namespace WikiLinks.Domain.MarkdownRules
 {
-    public class Header1Rule : MarkdownRule
+    public class Header1Rule : SingleLineMarkdownRule
     {
         private const string _MarkdownTag = "#";
         private const string _HtmlBeginTag = "<h1>";

--- a/WikiLinks.Domain/MarkdownRules/Header2Rule.cs
+++ b/WikiLinks.Domain/MarkdownRules/Header2Rule.cs
@@ -1,6 +1,6 @@
 namespace WikiLinks.Domain.MarkdownRules
 {
-    public class Header2Rule : MarkdownRule
+    public class Header2Rule : SingleLineMarkdownRule
     {
         private const string _MarkdownTag = "##";
         private const string _HtmlBeginTag = "<h2>";

--- a/WikiLinks.Domain/MarkdownRules/Header3Rule.cs
+++ b/WikiLinks.Domain/MarkdownRules/Header3Rule.cs
@@ -1,6 +1,6 @@
 namespace WikiLinks.Domain.MarkdownRules
 {
-    public class Header3Rule : MarkdownRule
+    public class Header3Rule : SingleLineMarkdownRule
     {
         private const string _MarkdownTag = "###";
         private const string _HtmlBeginTag = "<h3>";

--- a/WikiLinks.Domain/MarkdownRules/Header4Rule.cs
+++ b/WikiLinks.Domain/MarkdownRules/Header4Rule.cs
@@ -1,6 +1,6 @@
 namespace WikiLinks.Domain.MarkdownRules
 {
-    public class Header4Rule : MarkdownRule
+    public class Header4Rule : SingleLineMarkdownRule
     {
         private const string _MarkdownTag = "####";
         private const string _HtmlBeginTag = "<h4>";

--- a/WikiLinks.Domain/MarkdownRules/Header5Rule.cs
+++ b/WikiLinks.Domain/MarkdownRules/Header5Rule.cs
@@ -1,6 +1,6 @@
 namespace WikiLinks.Domain.MarkdownRules
 {
-    public class Header5Rule : MarkdownRule
+    public class Header5Rule : SingleLineMarkdownRule
     {
         private const string _MarkdownTag = "#####";
         private const string _HtmlBeginTag = "<h5>";

--- a/WikiLinks.Domain/MarkdownRules/Header6Rule.cs
+++ b/WikiLinks.Domain/MarkdownRules/Header6Rule.cs
@@ -1,6 +1,6 @@
 namespace WikiLinks.Domain.MarkdownRules
 {
-    public class Header6Rule : MarkdownRule
+    public class Header6Rule : SingleLineMarkdownRule
     {
         private const string _MarkdownTag = "######";
         private const string _HtmlBeginTag = "<h6>";

--- a/WikiLinks.Domain/MarkdownRules/ItalicRule.cs
+++ b/WikiLinks.Domain/MarkdownRules/ItalicRule.cs
@@ -1,6 +1,6 @@
 namespace WikiLinks.Domain.MarkdownRules
 {
-    public class ItalicRule : MarkdownRule
+    public class ItalicRule : SingleLineMarkdownRule
     {
         private const string _MarkdownTag = "_";
         private const string _HtmlBeginTag = "<i>";

--- a/WikiLinks.Domain/MarkdownRules/MultilineMarkdownRule.cs
+++ b/WikiLinks.Domain/MarkdownRules/MultilineMarkdownRule.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace WikiLinks.Domain.MarkdownRules
+{
+    public abstract class MultilineMarkdownRule
+    {
+        protected string MarkdownTag { get; }
+        protected string HtmlBeginTag => _htmlBeginTag;
+        protected string HtmlEndTag => _htmlEndTag;
+        protected TagStyle TagStyle { get; }
+        protected bool RequireSpace { get; } 
+
+        private readonly string _htmlBeginTag;
+        private readonly string _htmlEndTag;
+
+        protected internal MultilineMarkdownRule(string markdownTag, string htmlBeginTag, string htmlEndTag, TagStyle tagStyle = TagStyle.Matching, bool requireSpace = false)
+        {
+            MarkdownTag = markdownTag;
+            _htmlBeginTag = htmlBeginTag;
+            _htmlEndTag = htmlEndTag;
+            TagStyle = tagStyle;
+            RequireSpace = requireSpace;
+        }
+
+        public string Parse(string input)
+        {
+            var tag = MarkdownTag + (RequireSpace ? " " : "");
+            var lines = input.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            
+            var line = string.Empty;
+            var result = new StringBuilder();
+
+            for(int i = 0; i < lines.Length; i++)
+            {
+                if(TagStyle == TagStyle.Single)
+                {
+                    if(lines[i].StartsWith(tag))
+                    {
+                        if(i > 0 && lines[i - 1].StartsWith(tag))
+                        {
+                            result.Append(lines[i].Replace(tag, string.Empty));
+                        }
+                        else
+                        {
+                            result.Append(lines[i].Replace(tag, HtmlBeginTag));
+                        }
+
+                        if((i < lines.Length - 1 && !lines[i + 1].StartsWith(tag)) || i == lines.Length -1)
+                        {
+                            result.AppendLine(HtmlEndTag);       
+                        }
+                        else
+                        {
+                            result.AppendLine();
+                        }
+                    }
+                    else
+                    {
+                        result.AppendLine(lines[i]);
+                    }
+                }
+            }
+
+            return result.ToString();
+        }
+    }
+}

--- a/WikiLinks.Domain/MarkdownRules/MultilineMarkdownRule.cs
+++ b/WikiLinks.Domain/MarkdownRules/MultilineMarkdownRule.cs
@@ -54,12 +54,13 @@ namespace WikiLinks.Domain.MarkdownRules
                         }
                         else
                         {
-                            result.AppendLine();
+                            result.Append(Environment.NewLine);
                         }
                     }
                     else
                     {
-                        result.AppendLine(lines[i]);
+                        result.Append(lines[i])
+                              .Append(Environment.NewLine);
                     }
                 }
             }

--- a/WikiLinks.Domain/MarkdownRules/MultilineMarkdownRule.cs
+++ b/WikiLinks.Domain/MarkdownRules/MultilineMarkdownRule.cs
@@ -50,7 +50,8 @@ namespace WikiLinks.Domain.MarkdownRules
 
                         if((i < lines.Length - 1 && !lines[i + 1].StartsWith(tag)) || i == lines.Length -1)
                         {
-                            result.AppendLine(HtmlEndTag);       
+                            result.Append(HtmlEndTag)
+                                  .Append(Environment.NewLine);       
                         }
                         else
                         {

--- a/WikiLinks.Domain/MarkdownRules/SingleLineMarkdownRule.cs
+++ b/WikiLinks.Domain/MarkdownRules/SingleLineMarkdownRule.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace WikiLinks.Domain.MarkdownRules
 {
-    public abstract class MarkdownRule : IMarkdownRule
+    public abstract class SingleLineMarkdownRule : IMarkdownRule
     {
         protected string MarkdownTag { get; }
         protected string HtmlBeginTag => _htmlBeginTag;
@@ -14,7 +14,7 @@ namespace WikiLinks.Domain.MarkdownRules
         private readonly string _htmlBeginTag;
         private readonly string _htmlEndTag;
 
-        protected internal MarkdownRule(string markdownTag, string htmlBeginTag, string htmlEndTag, TagStyle tagStyle = TagStyle.Matching, bool requireSpace = false)
+        protected internal SingleLineMarkdownRule(string markdownTag, string htmlBeginTag, string htmlEndTag, TagStyle tagStyle = TagStyle.Matching, bool requireSpace = false)
         {
             MarkdownTag = markdownTag;
             _htmlBeginTag = htmlBeginTag;

--- a/WikiLinks.Test/Unit/MultiLineMarkdown_Test.cs
+++ b/WikiLinks.Test/Unit/MultiLineMarkdown_Test.cs
@@ -7,9 +7,10 @@ namespace WikiLinks.Test.Unit
     {
         [Theory]
         [Trait("Category", "unit")]
-        [InlineData("> hello", "<blockquote><pre>hello</pre></blockquote>")]
-        [InlineData("> hello\n> world", "<blockquote><pre>hello\nworld</pre></blockquote>")]
-        [InlineData("> hello\n> world\n> !", "<blockquote><pre>hello\nworld\n!</pre></blockquote>")]
+        [InlineData("> hello", "<blockquote><pre>hello</pre></blockquote>\n")]
+        [InlineData("> hello\n> world", "<blockquote><pre>hello\nworld</pre></blockquote>\n")]
+        [InlineData("> hello\n> world\n> !", "<blockquote><pre>hello\nworld\n!</pre></blockquote>\n")]
+        [InlineData("> hello\n> world\n> !\n", "<blockquote><pre>hello\nworld\n!</pre></blockquote>\n\n")]
         public void ParseBlockquote(string input, string expected)
         {
             //Assemble

--- a/WikiLinks.Test/Unit/MultiLineMarkdown_Test.cs
+++ b/WikiLinks.Test/Unit/MultiLineMarkdown_Test.cs
@@ -29,7 +29,7 @@ namespace WikiLinks.Test.Unit
             var result = bqr.Parse(input);
 
             //Assert
-            Assert.Equal(expected, result.Replace(Environment.NewLine, "\n"));
+            Assert.Equal(expected, result);
         }
     }
 }

--- a/WikiLinks.Test/Unit/MultiLineMarkdown_Test.cs
+++ b/WikiLinks.Test/Unit/MultiLineMarkdown_Test.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using WikiLinks.Domain.MarkdownRules;
 using Xunit;
 
@@ -6,12 +7,19 @@ namespace WikiLinks.Test.Unit
 {
     public class MultiLineMarkdown_Test
     {
+
+        public static IEnumerable<object[]> BlockquoteData =>
+            new[] 
+            {
+                new object[] { $"> hello", $"<blockquote><pre>hello</pre></blockquote>{Environment.NewLine}" },
+                new object[] { $"> hello{Environment.NewLine}> world", $"<blockquote><pre>hello{Environment.NewLine}world</pre></blockquote>{Environment.NewLine}" },
+                new object[] { $"> hello{Environment.NewLine}> world{Environment.NewLine}> !", $"<blockquote><pre>hello{Environment.NewLine}world{Environment.NewLine}!</pre></blockquote>{Environment.NewLine}" },
+                new object[] { $"> hello{Environment.NewLine}> world{Environment.NewLine}> !{Environment.NewLine}", $"<blockquote><pre>hello{Environment.NewLine}world{Environment.NewLine}!</pre></blockquote>{Environment.NewLine}{Environment.NewLine}" }
+            };
+
         [Theory]
         [Trait("Category", "unit")]
-        [InlineData("> hello", "<blockquote><pre>hello</pre></blockquote>\n")]
-        [InlineData("> hello\n> world", "<blockquote><pre>hello\nworld</pre></blockquote>\n")]
-        [InlineData("> hello\n> world\n> !", "<blockquote><pre>hello\nworld\n!</pre></blockquote>\n")]
-        [InlineData("> hello\n> world\n> !\n", "<blockquote><pre>hello\nworld\n!</pre></blockquote>\n\n")]
+        [MemberData(nameof(BlockquoteData))]
         public void ParseBlockquote(string input, string expected)
         {
             //Assemble

--- a/WikiLinks.Test/Unit/MultiLineMarkdown_Test.cs
+++ b/WikiLinks.Test/Unit/MultiLineMarkdown_Test.cs
@@ -1,3 +1,4 @@
+using System;
 using WikiLinks.Domain.MarkdownRules;
 using Xunit;
 
@@ -20,7 +21,7 @@ namespace WikiLinks.Test.Unit
             var result = bqr.Parse(input);
 
             //Assert
-            Assert.Equal(expected, result);
+            Assert.Equal(expected.Replace("\n", Environment.NewLine), result);
         }
     }
 }

--- a/WikiLinks.Test/Unit/MultiLineMarkdown_Test.cs
+++ b/WikiLinks.Test/Unit/MultiLineMarkdown_Test.cs
@@ -1,0 +1,25 @@
+using WikiLinks.Domain.MarkdownRules;
+using Xunit;
+
+namespace WikiLinks.Test.Unit
+{
+    public class MultiLineMarkdown_Test
+    {
+        [Theory]
+        [Trait("Category", "unit")]
+        [InlineData("> hello", "<blockquote><pre>hello</pre></blockquote>")]
+        [InlineData("> hello\n> world", "<blockquote><pre>hello\nworld</pre></blockquote>")]
+        [InlineData("> hello\n> world\n> !", "<blockquote><pre>hello\nworld\n!</pre></blockquote>")]
+        public void ParseBlockquote(string input, string expected)
+        {
+            //Assemble
+            var bqr = new BlockquoteRule();
+
+            //Act
+            var result = bqr.Parse(input);
+
+            //Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/WikiLinks.Test/Unit/MultiLineMarkdown_Test.cs
+++ b/WikiLinks.Test/Unit/MultiLineMarkdown_Test.cs
@@ -21,7 +21,7 @@ namespace WikiLinks.Test.Unit
             var result = bqr.Parse(input);
 
             //Assert
-            Assert.Equal(expected.Replace("\n", Environment.NewLine), result);
+            Assert.Equal(expected, result.Replace(Environment.NewLine, "\n"));
         }
     }
 }

--- a/WikiLinks.Test/Unit/SingleLineMarkdown_Test.cs
+++ b/WikiLinks.Test/Unit/SingleLineMarkdown_Test.cs
@@ -6,9 +6,10 @@ using Xunit;
 
 namespace WikiLinks.Test.Unit
 {
-    public class MarkdownTest
+    public class SingleLineMarkdown_Test
     {
         [Theory]
+        [Trait("Category", "unit")]
         [InlineData("hello **world**", "hello <b>world</b>")]
         [InlineData("hello **world **", "hello <b>world </b>")]
         [InlineData("hello ** world**", "hello <b> world</b>")]
@@ -21,6 +22,7 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
+        [Trait("Category", "unit")]
         [InlineData("**hello** **world**", "<b>hello</b> <b>world</b>")]
         [InlineData("**hello ** **world **", "<b>hello </b> <b>world </b>")]
         [InlineData("** hello** ** world**", "<b> hello</b> <b> world</b>")]
@@ -33,6 +35,7 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
+        [Trait("Category", "unit")]
         [InlineData("hello _world_", "hello <i>world</i>")]
         [InlineData("hello _world _", "hello <i>world </i>")]
         [InlineData("hello _ world_", "hello <i> world</i>")]
@@ -45,6 +48,7 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
+        [Trait("Category", "unit")]
         [InlineData("_hello_ _world_", "<i>hello</i> <i>world</i>")]
         [InlineData("_hello _ _world _", "<i>hello </i> <i>world </i>")]
         [InlineData("_ hello_ _ world_", "<i> hello</i> <i> world</i>")]
@@ -57,6 +61,7 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
+        [Trait("Category", "unit")]
         [InlineData("###### hello ###### world", "<h6>hello</h6> world")]
         [InlineData("###### hello world", "<h6>hello world</h6>")]
         [InlineData(" ###### hello world", " <h6>hello world</h6>")]
@@ -68,6 +73,7 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
+        [Trait("Category", "unit")]
         [InlineData("##### hello ##### world", "<h5>hello</h5> world")]
         [InlineData("##### hello world", "<h5>hello world</h5>")]
         [InlineData(" ##### hello world", " <h5>hello world</h5>")]
@@ -79,6 +85,7 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
+        [Trait("Category", "unit")]
         [InlineData("#### hello #### world", "<h4>hello</h4> world")]
         [InlineData("#### hello world", "<h4>hello world</h4>")]
         [InlineData(" #### hello world", " <h4>hello world</h4>")]
@@ -90,6 +97,7 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
+        [Trait("Category", "unit")]
         [InlineData("### hello ### world", "<h3>hello</h3> world")]
         [InlineData("### hello world", "<h3>hello world</h3>")]
         [InlineData(" ### hello world", " <h3>hello world</h3>")]
@@ -101,6 +109,7 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
+        [Trait("Category", "unit")]
         [InlineData("## hello ## world", "<h2>hello</h2> world")]
         [InlineData("## hello world", "<h2>hello world</h2>")]
         [InlineData(" ## hello world", " <h2>hello world</h2>")]
@@ -112,6 +121,7 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
+        [Trait("Category", "unit")]
         [InlineData("# hello # world", "<h1>hello</h1> world")]
         [InlineData("# hello world", "<h1>hello world</h1>")]
         [InlineData(" # hello world", " <h1>hello world</h1>")]
@@ -123,6 +133,7 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
+        [Trait("Category", "unit")]
         [InlineData("`hello` world", "<code><pre>hello</pre></code> world")]
         [InlineData("`hello world`", "<code><pre>hello world</pre></code>")]
         [InlineData("hello `world`", "hello <code><pre>world</pre></code>")]
@@ -136,6 +147,7 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
+        [Trait("Category", "integration")]
         [InlineData("**hello world")]
         [InlineData("hello _world")]
         public void Parse_UnmatchedTags(string inital)
@@ -148,6 +160,7 @@ namespace WikiLinks.Test.Unit
         }
 
         [Theory]
+        [Trait("Category", "integration")]
         [InlineData("")]
         [InlineData("  ")]
         [InlineData(null)]

--- a/WikiLinks.Test/Unit/SingleLineMarkdown_Test.cs
+++ b/WikiLinks.Test/Unit/SingleLineMarkdown_Test.cs
@@ -16,8 +16,13 @@ namespace WikiLinks.Test.Unit
         [InlineData("hello ** world **", "hello <b> world </b>")]
         public void ParseBold_Single(string initial, string expected)
         {
+            //Assemble
             var br = new BoldRule();
+            
+            //Act
             var result = br.Parse(initial);
+            
+            //Assert
             Assert.Equal(expected, result);
         }
 
@@ -29,8 +34,13 @@ namespace WikiLinks.Test.Unit
         [InlineData("** hello ** ** world **", "<b> hello </b> <b> world </b>")]
         public void ParseBold_Multiple(string initial, string expected)
         {
+            //Assemble
             var br = new BoldRule();
+            
+            //Act
             var result = br.Parse(initial);
+            
+            //Assert
             Assert.Equal(expected, result);
         }
 
@@ -42,8 +52,13 @@ namespace WikiLinks.Test.Unit
         [InlineData("hello _ world _", "hello <i> world </i>")]
         public void ParseItalic_Single(string initial, string expected)
         {
+            //Assemble
             var ir = new ItalicRule();
+            
+            //Act
             var result = ir.Parse(initial);
+            
+            //Assert
             Assert.Equal(expected, result);
         }
 
@@ -55,8 +70,13 @@ namespace WikiLinks.Test.Unit
         [InlineData("_ hello _ _ world _", "<i> hello </i> <i> world </i>")]
         public void ParseItalic_Multiple(string initial, string expected)
         {
+            //Assemble
             var ir = new ItalicRule();
+            
+            //Act
             var result = ir.Parse(initial);
+            
+            //Assert
             Assert.Equal(expected, result);
         }
 
@@ -67,8 +87,13 @@ namespace WikiLinks.Test.Unit
         [InlineData(" ###### hello world", " <h6>hello world</h6>")]
         public void ParseHeader6(string initial, string expected)
         {
+            //Assemble
             var hr = new Header6Rule();
+            
+            //Act
             var result = hr.Parse(initial);
+            
+            //Assert
             Assert.Equal(expected, result);
         }
 
@@ -79,8 +104,13 @@ namespace WikiLinks.Test.Unit
         [InlineData(" ##### hello world", " <h5>hello world</h5>")]
         public void ParseHeader5(string initial, string expected)
         {
+            //Assemble
             var hr = new Header5Rule();
+            
+            //Act
             var result = hr.Parse(initial);
+            
+            //Assert
             Assert.Equal(expected, result);
         }
 
@@ -91,8 +121,13 @@ namespace WikiLinks.Test.Unit
         [InlineData(" #### hello world", " <h4>hello world</h4>")]
         public void ParseHeader4(string initial, string expected)
         {
+            //Assemble
             var hr = new Header4Rule();
+            
+            //Act
             var result = hr.Parse(initial);
+            
+            //Assert
             Assert.Equal(expected, result);
         }
 
@@ -103,8 +138,13 @@ namespace WikiLinks.Test.Unit
         [InlineData(" ### hello world", " <h3>hello world</h3>")]
         public void ParseHeader3(string initial, string expected)
         {
+            //Assemble
             var hr = new Header3Rule();
+            
+            //Act
             var result = hr.Parse(initial);
+            
+            //Assert
             Assert.Equal(expected, result);
         }
 
@@ -115,8 +155,13 @@ namespace WikiLinks.Test.Unit
         [InlineData(" ## hello world", " <h2>hello world</h2>")]
         public void ParseHeader2(string initial, string expected)
         {
+            //Assemble
             var hr = new Header2Rule();
+            
+            //Act
             var result = hr.Parse(initial);
+            
+            //Assert
             Assert.Equal(expected, result);
         }
 
@@ -127,8 +172,13 @@ namespace WikiLinks.Test.Unit
         [InlineData(" # hello world", " <h1>hello world</h1>")]
         public void ParseHeader1(string initial, string expected)
         {
+            //Assemble
             var hr = new Header1Rule();
+            
+            //Act
             var result = hr.Parse(initial);
+            
+            //Assert
             Assert.Equal(expected, result);
         }
 
@@ -141,8 +191,13 @@ namespace WikiLinks.Test.Unit
         [InlineData("`hello ` world", "<code><pre>hello </pre></code> world")]
         public void ParseCodeLine(string initial, string expected)
         {
+            //Assemble
             var hr = new CodeRule();
+            
+            //Act
             var result = hr.Parse(initial);
+            
+            //Assert
             Assert.Equal(expected, result);
         }
 
@@ -152,10 +207,14 @@ namespace WikiLinks.Test.Unit
         [InlineData("hello _world")]
         public void Parse_UnmatchedTags(string inital)
         {
+            //Assemble
             var rules = GetRules();
+            
+            //Act
             var md = new Markdown(rules);
             var result = md.Parse(inital);
 
+            //Assert
             Assert.Equal(inital + Environment.NewLine, result);
         }
 
@@ -166,10 +225,14 @@ namespace WikiLinks.Test.Unit
         [InlineData(null)]
         public void Parse_NullOrWhiteSpace(string initial)
         {
+            //Assemble
             var rules = GetRules();
+            
+            //Act
             var md = new Markdown(rules);
             var result = md.Parse(initial);
 
+            //Assert
             Assert.Empty(result);
         }
 


### PR DESCRIPTION
Renaming MarkdownRule to the more appropriate SingleLineMarkdownRule to allow for multiline rules